### PR TITLE
feat: add support for extra fonts in converter

### DIFF
--- a/lib/src/converter.dart
+++ b/lib/src/converter.dart
@@ -17,6 +17,7 @@ class Converter {
   static pw.Font? regularFont;
   static pw.Font? boldFont;
   static pw.Font? italicFont;
+  static List<pw.Font> extra = [];
 
   static Future<void> loadFont(String path, Function(pw.Font) setter) async {
     final fontBytes = await File(path).readAsBytes();
@@ -205,6 +206,7 @@ pw.TextStyle _defaultTextStyle() {
           Converter.regularFont,
           Converter.boldFont,
           Converter.italicFont,
+          ...Converter.extra,
         ].where((font) => font != null).cast<pw.Font>().toList(),
   );
 }


### PR DESCRIPTION
Add a new static list for extra fonts in the Converter class and  include it in the default text style method. This change allows  for greater flexibility in font usage by enabling the addition  of custom fonts without modifying existing font properties.